### PR TITLE
Make the data field of the Bounce and Bounced messages optional

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -269,7 +269,7 @@ where
         games: Option<Vec<String>>,
         slots: Option<Vec<String>>,
         tags: Vec<String>,
-        data: serde_json::Value,
+        data: Option<serde_json::Value>,
     ) -> Result<(), ArchipelagoError> {
         self.send(ClientMessage::Bounce(Bounce {
             games,
@@ -423,7 +423,7 @@ impl ArchipelagoClientSender {
         games: Option<Vec<String>>,
         slots: Option<Vec<String>>,
         tags: Vec<String>,
-        data: serde_json::Value,
+        data: Option<serde_json::Value>,
     ) -> Result<(), ArchipelagoError> {
         self.send(ClientMessage::Bounce(Bounce {
             games,

--- a/src/protocol/bounce.rs
+++ b/src/protocol/bounce.rs
@@ -21,7 +21,7 @@ struct InternalBounced {
     pub slots: Option<Vec<i64>>,
     #[serde(default)]
     pub tags: Vec<String>,
-    pub data: Value,
+    pub data: Option<Value>,
 }
 
 // Deserialize Bounced based on its tags.
@@ -36,9 +36,12 @@ impl<'de> Deserialize<'de> for Bounced {
                 games: internal.games,
                 slots: internal.slots,
                 tags: internal.tags,
-                data: BounceData::DeathLink(match serde_json::from_value(internal.data) {
-                    Ok(data) => data,
-                    Err(err) => return Err(D::Error::custom(err)),
+                data: BounceData::DeathLink(match internal.data {
+                    None => return Err(D::Error::custom("DeathLink Bounce should have data, but was None.")),
+                    Some(data) => match serde_json::from_value(data) {
+                        Ok(data) => data,
+                        Err(err) => return Err(D::Error::custom(err)),
+                    },
                 }),
             })
         } else {
@@ -55,7 +58,7 @@ impl<'de> Deserialize<'de> for Bounced {
 #[derive(Debug, Clone)]
 pub enum BounceData {
     DeathLink(DeathLink),
-    Generic(Value),
+    Generic(Option<Value>),
 }
 
 #[serde_as]


### PR DESCRIPTION
The `data` field in both the Bounce and Bounced messages are optional despite currently not being marked as such in the protocol documentation. https://github.com/ArchipelagoMW/Archipelago/pull/5794 already exists to update the protocol documentation, but this is already happening in practice, for example in the CommonClient (https://github.com/ArchipelagoMW/Archipelago/issues/5725). This PR changes the `data` fields of both affected messages to be optional.