### PR TITLE
Manually handle WebSocket close events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.0.1
+## 2.1.1
+
+* Fix a bug where a connection closing was improperly handled by 
+
+## 2.1.0
 
 * Broaden dependencies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.1
 
-* Fix a bug where a connection closing was improperly handled by 
+* Fix a bug where a connection closing was improperly handled and could cause
+  panics.
 
 ## 2.1.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archipelago_rs"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 
 description = "A Rust client for the archipelago.gg multiworld randomizer"

--- a/src/connection/socket.rs
+++ b/src/connection/socket.rs
@@ -344,6 +344,13 @@ impl<S: DeserializeOwned + 'static> Socket<S> {
                         .push_back(Err(ProtocolError::BinaryMessage(bytes.to_vec()).into()));
                 }
 
+                Ok(Message::Close(_)) => {
+                    debug!("--> [closed]");
+                    let err = Error::WebSocket(tungstenite::Error::ConnectionClosed);
+                    self.messages.push_back(Err(err));
+                    break;
+                }
+
                 // Other message types like pings, frames, and closes are
                 // handled internally by the tungstenite. We can ignore them.
                 Ok(_) => {}
@@ -353,6 +360,7 @@ impl<S: DeserializeOwned + 'static> Socket<S> {
                 }
 
                 Err(err) => {
+                    debug!("--> [error] {err:?}");
                     let err = Error::from(err);
                     let fatal = err.is_fatal();
                     self.messages.push_back(Err(err));


### PR DESCRIPTION
Tungstenite's documentation suggests it will automatically convert these into error events, but this doesn't seem to be the case in practice.