### PR TITLE
Handle the case where the server sends negative hint points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.0.0
+
+* `Client::hint_points` now returns `i64` rather than `u64`. A negative value
+  indicates that the player is in "hint debt".
+
+* `UpdatedField::HintPoints` similarly now contains an `i64` rather than a
+  `u64`.
+
 ## 2.1.1
 
 * Fix a bug where a connection closing was improperly handled and could cause

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archipelago_rs"
-version = "2.1.1"
+version = "3.0.0"
 edition = "2024"
 
 description = "A Rust client for the archipelago.gg multiworld randomizer"

--- a/src/client.rs
+++ b/src/client.rs
@@ -571,7 +571,9 @@ impl<S: DeserializeOwned + 'static> Client<S> {
 
         for id in locations {
             if matches!(self.local_locations_checked.insert(id, true), Some(false)) {
-                self.hint_points = self.hint_points.strict_add_unsigned(self.hint_points_per_check);
+                self.hint_points = self
+                    .hint_points
+                    .strict_add_unsigned(self.hint_points_per_check);
             }
         }
         Ok(())

--- a/src/client.rs
+++ b/src/client.rs
@@ -44,7 +44,7 @@ pub struct Client<S: DeserializeOwned + 'static = serde_json::Value> {
     permissions: PermissionMap,
     hint_cost_percentage: u8,
     hint_points_per_check: u64,
-    hint_points: u64,
+    hint_points: i64,
     seed_name: String,
     games: UstrMap<Game>,
     slot_data: S,
@@ -376,7 +376,11 @@ impl<S: DeserializeOwned + 'static> Client<S> {
     }
 
     /// The number of hint points the player currently has.
-    pub fn hint_points(&self) -> u64 {
+    ///
+    /// This can be negative to represent the player being in "hint debt", which
+    /// can occur if the server admin raises the hint cost after the player has
+    /// already spent down their hint points.
+    pub fn hint_points(&self) -> i64 {
         self.hint_points
     }
 
@@ -567,7 +571,7 @@ impl<S: DeserializeOwned + 'static> Client<S> {
 
         for id in locations {
             if matches!(self.local_locations_checked.insert(id, true), Some(false)) {
-                self.hint_points += self.hint_points_per_check;
+                self.hint_points = self.hint_points.strict_add_unsigned(self.hint_points_per_check);
             }
         }
         Ok(())

--- a/src/event.rs
+++ b/src/event.rs
@@ -144,7 +144,7 @@ pub enum UpdatedField {
     /// [Client.hint_points] has changed.
     ///
     /// This contains the previous value for the field.
-    HintPoints(u64),
+    HintPoints(i64),
 
     /// One or more players' aliases have changed.
     ///

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -449,7 +449,7 @@ pub(crate) struct Connected<S> {
     pub(crate) slot_data: S,
     #[serde_as(as = "HashMap<DisplayFromStr, _>")]
     pub(crate) slot_info: HashMap<u32, NetworkSlot>,
-    pub(crate) hint_points: u64,
+    pub(crate) hint_points: i64,
 }
 
 /// Deserializes a value of `Connected<S>`, except that if `S` is
@@ -505,7 +505,7 @@ pub(crate) struct RoomUpdate {
     pub(crate) hint_cost: Option<u8>,
     pub(crate) location_check_points: Option<u64>,
     // Copied from Connected
-    pub(crate) hint_points: Option<u64>,
+    pub(crate) hint_points: Option<i64>,
     pub(crate) players: Option<Vec<NetworkPlayer>>,
     pub(crate) checked_locations: Option<Vec<i64>>,
 }


### PR DESCRIPTION
This behavior is undocumented, but has been confirmed to exist in the Archipelago server implementation.